### PR TITLE
Added livenessProbe for pod restarts to handle timeout and connection issues.

### DIFF
--- a/charts/geonetwork/templates/geonetwork-deployment.yaml
+++ b/charts/geonetwork/templates/geonetwork-deployment.yaml
@@ -62,6 +62,12 @@ spec:
             - name: tcp
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /geonetwork
+              port: 8080
+            initialDelaySeconds: 120
+            periodSeconds: 60
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it:**

- Added livenessProbe for pod restarts to handle timeout and connection issues.

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):** fixes #354605

Special notes for your reviewer:
Signed-off-by: Uday Kiran Y [udaykiran.y@gmail.com](mailto:udaykiran.y@gmail.com)