### PR TITLE
Apply resource requests and limits for geonetwork.

### DIFF
--- a/charts/geonetwork/values.yaml
+++ b/charts/geonetwork/values.yaml
@@ -19,7 +19,7 @@ geoservice:
   type: ClusterIP
   port: 8080
 
-resources: {}
+#resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -30,6 +30,14 @@ resources: {}
 # requests:
 #   cpu: 100m
 #   memory: 128Mi
+
+resources:
+  requests:
+    memory: "1200Mi"
+    cpu: "10m"
+  limits:
+    memory: "1500Mi"
+    cpu: "1400m"
 
 nodeSelector: {}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

- This will apply the resource requests and limit for the geonetwork Kubernetes deployment .

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):** fixes #366773

Special notes for your reviewer:
Signed-off-by: Uday Kiran Y [udaykiran.y@gmail.com](mailto:udaykiran.y@gmail.com)