### PR TITLE
Added the force switch to az acr import command to overwrite existing

### DIFF
--- a/pipeline/steps-import-docker-images.yaml
+++ b/pipeline/steps-import-docker-images.yaml
@@ -14,6 +14,7 @@ steps:
       docker login $(acrContainerRegistryPre) -u $(acrUser) -p $PASSWORD
       echo "importing container"
       az acr import \
+        --force \
         --name $(acrContainerRegistryPreShort) \
         --source $(acrContainerRepositoryGeoNetwork):$(imageTag) \
         --image $(acrContainerRepositoryGeoNetwork):$(imageTag) \


### PR DESCRIPTION
What one thing this PR does?
Added the --force switch to the az acr import command to ensure that if a pipeline partially completes then it can be rerun and the image is overwritten. Curently it fails.

Task details
Bug 432929 Pipeline failing for container import if it already exists container registry import